### PR TITLE
Remove accidental duplication in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ There are different options of how to build Winamp:
 
 ### Dependencies
 
-1. Use a build_winampAll_2019.cmd script file that makes 4 versions x86/x64 (Debug and Release). In this case Visual Studio IDE not running.
-2. Use a winampAll_2019.sln file to build and debug in Visual Studio IDE.
-
 #### libvpx
 We take libvpx from https://github.com/ShiftMediaProject/libvpx, modify it and pack to archive.
 Run unpack_libvpx_v1.8.2_msvc16.cmd to unpack.


### PR DESCRIPTION
Removes lines from the "Usage" section that were duplicated into the "Dependencies" section.