### PR TITLE
LICENSE.md: remove misleading phrasing in preamble

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ This License governs the use, modification, and distribution of the Winamp softw
 By using, Modifying, or distributing this software, you agree to the following terms:
 
 ## Preamble
-The Winamp Collaborative License is a free, copyleft license for software and other kinds of works. It is designed to ensure that you have the freedom to use, Modify, and study the software, but with certain restrictions on the distribution of modifications to maintain the integrity and collaboration of the project.
+The Winamp Collaborative License is designed to ensure that you have the freedom to use and study the software, but with certain restrictions on the distribution of modifications to maintain the integrity and collaboration of the project.
 
 ## TERMS AND CONDITIONS
 


### PR DESCRIPTION
The license is not a copyleft license as it does not grant the four freedoms.  In particular, it restricts distribution making it a proprietary license better referred to as source-available license.

Fun fact: by creating this pull request I’ve technically violated the license since I had to create fork of the software.