### PR TITLE
chore: use "clean up" as verb instead of adjective, add space before dots

### DIFF
--- a/install-packages.cmd
+++ b/install-packages.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-echo "Cleanup the environment..."
+echo "Clean up the environment ..."
 IF EXIST "Src\external_dependencies\vcpkg" (
 	echo Deleting "Src\external_dependencies\vcpkg" ...
 	rmdir /S /Q "Src\external_dependencies\vcpkg"
@@ -20,22 +20,22 @@ IF EXIST ".\vcpkg" (
 )
 
 if "%computername%"=="NullsoftBuildbox" (
-echo "Uncompress the Qt Debug dlls..."
+echo "Uncompress the Qt Debug dlls ..."
 .\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Debug_Commercial.7z.001 -y -o.\Qt\DLL_5.12_x86
 ren ".\Qt\DLL_5.12_x86\Debug_Commercial\" ".\Qt\DLL_5.12_x86\Debug"
 
-echo "Uncompress the Qt Release dlls..."
+echo "Uncompress the Qt Release dlls ..."
 .\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Release_Commercial.7z.001 -y -o.\Qt\DLL_5.12_x86
 ren ".\Qt\DLL_5.12_x86\Release_Commercial\" ".\Qt\DLL_5.12_x86\Release\"
 ) ELSE (
-echo "Uncompress the Qt Debug dlls..."
+echo "Uncompress the Qt Debug dlls ..."
 .\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Debug.7z.001 -y -o.\Qt\DLL_5.12_x86
 
-echo "Uncompress the Qt Release dlls..."
+echo "Uncompress the Qt Release dlls ..."
 .\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Release.7z.001 -y -o.\Qt\DLL_5.12_x86
 )
 
-echo "Uncompress \Src\external_dependencies\CEF..."
+echo "Uncompress \Src\external_dependencies\CEF ..."
 .\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Src\external_dependencies\CEF.7z.001 -y -o.\Src\external_dependencies
 
 


### PR DESCRIPTION
shortened sentences should have space before the three dots, no space is for shortened words