### PR TITLE
Wcl version 1.1.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,15 +1,15 @@
-# Winamp Collaborative License (WCL) Version 1.0.1
+# Winamp Collaborative License (WCL) Version 1.1.0
 
-This License governs the use, modification, and distribution of the Winamp software. 
+This License governs the use, modification, and distribution of the Winamp software.
 By using, Modifying, or distributing this software, you agree to the following terms:
 
 ## Preamble
-The Winamp Collaborative License is a free, copyleft license for software and other kinds of works. It is designed to ensure that you have the freedom to use, Modify, and study the software, but with certain restrictions on the distribution of modifications to maintain the integrity and collaboration of the project.
+The Winamp Collaborative License is a [Source-available](https://en.wikipedia.org/wiki/Source_available) license for software and other kinds of works. It is designed to ensure that you have the freedom to use, Modify, and study the software, but with certain restrictions on the distribution of modifications to maintain the integrity and collaboration of the project.
 
 ## TERMS AND CONDITIONS
 
 ### 1. Definitions
-- "This License" refers to version 1.0.1 of the Winamp Collaborative License.
+- "This License" refers to version 1.1.0 of the Winamp Collaborative License.
 - "The Program" refers to any copyrightable work Licensed under this License.
 - "You" refers to each Licensee, whether an individual or organization.
 - "Modify" means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.
@@ -29,7 +29,7 @@ You are granted the right to Modify the software for private use only. You may m
 - Waiver of Rights: You waive any rights to claim authorship of the contributions or to object to any distortion, mutilation, or other modifications of the contributions.
 
 ### 5. Restrictions
-- No Distribution of Modified Versions: You may not distribute modified versions of the software, whether in source or binary form.
+- No Distribution of Modified Versions: You may not distribute modified versions of the software in binary form.
 - Official Distribution: Only the maintainers of the official repository are allowed to distribute the software and its modifications.
 
 ### 6. No Sublicensing
@@ -68,12 +68,12 @@ If the Program collects user data, you must provide clear notice and obtain any 
 ### 15. Support and Updates
 The Licensor has no obligation to provide support, updates, or maintenance for the Program. Any such support, updates, or maintenance will be provided at the sole discretion of the Licensor.
 
-### 16. Compliance 
+### 16. Compliance
 You must comply with all applicable laws and regulations in connection with your use of the Program.
 
 ### 17. Miscellaneous
 - Governing Law and Jurisdiction: This License shall be governed by and construed in accordance with the laws of Belgium. Any disputes arising out of or in connection with this License shall be subject to the exclusive jurisdiction of the courts located in Brussels, Belgium.
 - Severability: If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
 By using, Modifying, or contributing to the software, you acknowledge that you have read, understood, and agree to be bound by these terms and conditions.
- 
+
 This custom License aims to maintain the collaborative nature of the project while restricting the distribution of modified versions.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Run `unpack_libvpx_v1.8.2_msvc16.cmd` to unpack.
 We take libmpg123 from [https://www.mpg123.de/download.shtml](https://www.mpg123.de/download.shtml), modify it, and pack it to archive.
 Run `unpack_libmpg123.cmd` to unpack and process the DLLs.
 
+#### MilkDrop2
+
+We take MilkDrop2 from [https://sourceforge.net/p/milkdrop2/code/ci/master/tree/src/vis_milk2/](https://sourceforge.net/p/milkdrop2/code/ci/master/tree/src/vis_milk2/), copy it in /Src/Plugins/Visualization/vis_milk2/
+
 #### OpenSSL
 
 You need to use `openssl-1.0.1u`. For that, you need to build a static version of these libs.


### PR DESCRIPTION
This is a serious proposal for Winamp Collaborative License (WCL) Version 1.1.0 with minimal changes. I would generally recommend using a copyleft license such as GPL-3.0-or-later or stick to a license that already exists for this project, but it is up to you how you wish to proceed with your project.

While not responsible for it, I want to apologize for all of the harassment you have seen from others in the issues and pull requests. I no longer use Winamp, but I spent countless hours listening to Winamp in the early 2000s. Be nice to each other. We don't have much time left.

Changes:

* LICENSE.md
  * Change `free, copyleft` to `[Source-available](https://en.wikipedia.org/wiki/Source_available)`. 
  * Remove the restriction of distributing modified source code while leaving binary form restriction.
  * Change versioning from 1.0.1 to 1.1.0.
  * Remove trailing blank space.
* README.md
  * Add MilkDrop2 to the dependencies section along with a link to the SourceForge page.

Reason:

I propose this change because these two controversial points seems to be one of the things that people are most angry about with this repository. This simple change would likely not make everyone happy, but maybe make everyone less angry.

The words [free](https://en.wikipedia.org/wiki/Free_software) and [copyleft](https://en.wikipedia.org/wiki/Copyleft) already have meanings in the software licensing space. [Source-available](https://en.wikipedia.org/wiki/Source_available) is the term for the in-between space where some freedom is allowed which seems to be the best description for this license.

I removed the distribution of source restriction because I expect you to want people to fork this repository in order to receive pull requests that might help Winamp. The GitHub TOS explicitly allow such a thing anyway.