### PR TITLE
Removing references of Qt in the packages install script

### DIFF
--- a/install-packages.cmd
+++ b/install-packages.cmd
@@ -19,22 +19,6 @@ IF EXIST ".\vcpkg" (
 	echo ".\vcpkg was deleted!"
 )
 
-if "%computername%"=="NullsoftBuildbox" (
-echo "Uncompress the Qt Debug dlls ..."
-.\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Debug_Commercial.7z.001 -y -o.\Qt\DLL_5.12_x86
-ren ".\Qt\DLL_5.12_x86\Debug_Commercial\" ".\Qt\DLL_5.12_x86\Debug"
-
-echo "Uncompress the Qt Release dlls ..."
-.\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Release_Commercial.7z.001 -y -o.\Qt\DLL_5.12_x86
-ren ".\Qt\DLL_5.12_x86\Release_Commercial\" ".\Qt\DLL_5.12_x86\Release\"
-) ELSE (
-echo "Uncompress the Qt Debug dlls ..."
-.\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Debug.7z.001 -y -o.\Qt\DLL_5.12_x86
-
-echo "Uncompress the Qt Release dlls ..."
-.\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Qt\DLL_5.12_x86\Release.7z.001 -y -o.\Qt\DLL_5.12_x86
-)
-
 echo "Uncompress \Src\external_dependencies\CEF ..."
 .\BuildTools\7-ZipPortable_22.01\App\7-Zip\7z.exe x .\Src\external_dependencies\CEF.7z.001 -y -o.\Src\external_dependencies
 


### PR DESCRIPTION
You guys removed the Qt directory but forgot to also remove references to it in your "install-packages.cmd" script.

What I suggest is that you rebase this commit: https://github.com/WinampDesktop/winamp/commit/16911d12a01f82fea5d851f98e9e702d80f881d5 into the initial commit that added the Qt directory and force push it (be careful), that should at least hide the change from history!

Otherwise, google how to remove the directory entirely from Git and its history .